### PR TITLE
[pt2] Supporting changes for using kubebuilder in apro.git

### DIFF
--- a/apis/getambassador.io/v3alpha1/stub.go
+++ b/apis/getambassador.io/v3alpha1/stub.go
@@ -1,4 +1,4 @@
-package v1
+package v3alpha1
 
 import (
 	"fmt"

--- a/cmd/amb-sidecar/filters/handler/middleware/stub.go
+++ b/cmd/amb-sidecar/filters/handler/middleware/stub.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	crd "github.com/datawire/apro/v2/apis/getambassador.io/v1beta2"
+	crd "github.com/datawire/apro/v2/apis/getambassador.io/v3alpha1"
 	"github.com/datawire/apro/v2/lib/filterapi"
 )
 


### PR DESCRIPTION
Rename the `v1beta2` package to `v3alpha1` to reflect what's going on in the actual apro.git.

# Related
 1. emissary: https://github.com/emissary-ingress/emissary/pull/3939
 2. apro-stubs: https://github.com/datawire/apro-stubs/pull/5 <-- this PR
 3. aes-ratelimit-1.3: https://github.com/datawire/aes-ratelimit/pull/18
 4. aes-ratelimit-1.4: https://github.com/datawire/aes-ratelimit/pull/19
 5. edge-stack: https://github.com/datawire/edge-stack/pull/30
 6. apro-1.14: https://github.com/datawire/apro/pull/2851
 7. apro-2.1: https://github.com/datawire/apro/pull/2848
